### PR TITLE
fix(uploads): correctly display (new) uploaded images in all image filetypes supported by ckeditor

### DIFF
--- a/actions/ckeditor/upload.php
+++ b/actions/ckeditor/upload.php
@@ -70,6 +70,8 @@ $ext = $upload->getClientOriginalExtension();
 
 $file->transfer($file->owner_guid, "ckeditor/{$hash}.{$ext}");
 
+$file->hash = $hash;
+$file->ext = $ext;
 $file->save();
 
 $url = elgg_normalize_url("ckeditor/image/{$user->guid}/{$hash}/{$ext}");

--- a/start.php
+++ b/start.php
@@ -140,10 +140,6 @@ function ckeditor_addons_page_handler($segments) {
 				exit;
 			}
 
-			if (!in_array($ext, array('jpg', 'gif'))) {
-				$ext = 'jpg';
-			}
-
 			if (isset($_SERVER['HTTP_IF_NONE_MATCH']) && trim($_SERVER['HTTP_IF_NONE_MATCH']) == "\"$hash\"") {
 				header("HTTP/1.1 304 Not Modified");
 				exit;

--- a/views/default/object/ckeditor_file.php
+++ b/views/default/object/ckeditor_file.php
@@ -5,17 +5,8 @@ use hypeJunction\CKFile;
 $entity = elgg_extract('entity', $vars);
 /* @var $entity CKFile */
 
-$hash = md5(file_get_contents($entity->getFilenameOnFilestore()));
-switch ($entity->getMimeType()) {
-	case 'image/gif' :
-		$ext = 'gif';
-		break;
-	default :
-		$ext = 'jpg';
-}
-
 $img = elgg_format_element('img', array(
-	'src' => elgg_normalize_url("ckeditor/image/$entity->owner_guid/$hash/$ext"),
+	'src' => elgg_normalize_url("ckeditor/image/$entity->owner_guid/$entity->hash/$entity->ext"),
 	'class' => 'ckeditor-browser-image',
 	'data-callback' => elgg_extract('ckeditor_callback', $vars),
 	'width' => 100,


### PR DESCRIPTION
Sorry for https://github.com/hypeJunction/Elgg-ckeditor_addons/commit/21dd9b18f6ebe7876e5516cdc3ae682fcb8f47c9 that did not work for all filetypes (e.g. not for png). Now hash and extension are saved as metadata and there's no longer a check on file extension in the pagehandler.

Downside is that saving the hash and extension as metadata will not help with already existing image uploads. On the other hand any images uploaded with the released 5.0.0 version haven't been saved as ckeditor_file entities anyway and can't be re-selected for display in the image browser anyway.